### PR TITLE
support customized descriptor for jar and war

### DIFF
--- a/antx/autoconfig/src/main/java/com/alibaba/antx/config/entry/ConfigEntryFactoryImpl.java
+++ b/antx/autoconfig/src/main/java/com/alibaba/antx/config/entry/ConfigEntryFactoryImpl.java
@@ -139,9 +139,9 @@ public class ConfigEntryFactoryImpl implements ConfigEntryFactory {
             };
         }
 
-        entry.setDescriptorPatterns(new PatternSet("META-INF/**/auto-config.xml"));
+        entry.setDescriptorPatterns(new PatternSet(settings.getDescriptorPatterns(), new PatternSet("META-INF/**/auto-config.xml")).addDefaultExcludes());
 
-        entry.setPackagePatterns(new PatternSet("WEB-INF/lib/*.jar"));
+        entry.setPackagePatterns(new PatternSet(settings.getPackagePatterns(), new PatternSet("WEB-INF/lib/*.jar")).addDefaultExcludes());
 
         return entry;
     }
@@ -167,9 +167,9 @@ public class ConfigEntryFactoryImpl implements ConfigEntryFactory {
             };
         }
 
-        entry.setDescriptorPatterns(new PatternSet("META-INF/**/auto-config.xml"));
+        entry.setDescriptorPatterns(new PatternSet(settings.getDescriptorPatterns(), new PatternSet("META-INF/**/auto-config.xml")).addDefaultExcludes());
 
-        entry.setPackagePatterns(new PatternSet("**/*.jar, **/*.war, **/*.rar, **/*.ear"));
+        entry.setPackagePatterns(new PatternSet(settings.getPackagePatterns(), new PatternSet("**/*.jar, **/*.war, **/*.rar, **/*.ear")).addDefaultExcludes());
 
         return entry;
     }


### PR DESCRIPTION
autoconfig claims to support customised descriptor, but it doesn't work when configuring jar and war. This PR fix this.
